### PR TITLE
Composer.json: Magento Composer Installer should be a suggestion instead of a requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 			"email": "info@sessiondigital.de"
 		}
 	],
-	"require": {
-		"magento-hackathon/magento-composer-installer": "*"
+	"suggest": {
+		"magento-hackathon/magento-composer-installer": "Allows to manage this package as a dependency"
 	}
 }


### PR DESCRIPTION
This PR resolves the following `composer validate` warning:

```
require.magento-hackathon/magento-composer-installer : unbound version constraints (*) should be avoided
```