### PR TITLE
Escape double quotes in textbox values

### DIFF
--- a/app/design/adminhtml/default/default/template/jarlssen/faster_attribute_option_edit/options-fix.phtml
+++ b/app/design/adminhtml/default/default/template/jarlssen/faster_attribute_option_edit/options-fix.phtml
@@ -292,12 +292,15 @@ if($attributeType == 'multiselect') {
 
             if(element) {
                 var tdElements = $(element).select('div.replace-content');
+                var escapeQuote = function(rawStr) {
+                    return rawStr.replace(/"/g, '&quot;');
+                };
 
                 for(var i = 0; i < tdElements.length; i++) {
                     // Creates the checkbox
                     if($(tdElements[i]).hasClassName('checkbox-radio-container')) {
                         var value = $(tdElements[i]).readAttribute('id').replace('option_', '');
-                        $(tdElements[i]).replace('<input class="input-radio" type="' + optionDefaultInputType + '" name="default[]" value="' + value + '" />');
+                        $(tdElements[i]).replace('<input class="input-radio" type="' + optionDefaultInputType + '" name="default[]" value="' + escapeQuote(value) + '" />');
                         continue;
                     }
 
@@ -305,7 +308,7 @@ if($attributeType == 'multiselect') {
                     var name = $(tdElements[i]).readAttribute('id');
                     var kclass = $(tdElements[i]).readAttribute('class');
 
-                    $(tdElements[i]).replace('<input class="' + kclass + '" name="' + name + '" value="' + value + '" />');
+                    $(tdElements[i]).replace('<input class="' + kclass + '" name="' + name + '" value="' + escapeQuote(value) + '" />');
                 }
             }
         },


### PR DESCRIPTION
There's currently a bug where, if the attribute label has a double quote in it, the browser will interpret it as terminating the `value` parameter in `<input>` and truncate the string after the first instance of the double quote.

So a textbox rendered as `<input type="text" value="{{media url="myimg.png"}}" />` becomes: `<input type="text" value="{{media url=" />` in the DOM.

![before-after](https://cloud.githubusercontent.com/assets/4731130/16823112/89384eee-492f-11e6-9303-6c216f1b09b9.png)

This PR changes the textbox rendering function to convert the double quote character to its html entity to fix this.
